### PR TITLE
Make postcode cleanup optional

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -179,7 +179,7 @@ const cleanupInput = (input, replacements = [], options = {}) => {
     input.attention = unknownComponents.map((c) => input[c]).join(', ');
   }
 
-  if (input.postcode) {
+  if (input.postcode && options.cleanupPostcode !== false) {
     // convert to string
     input.postcode = `${input.postcode}`;
     const multiCodeRegex = /^(\d{5}),\d{5}/;
@@ -322,6 +322,7 @@ module.exports = {
     abbreviate: false,
     output: 'string',
     appendCountry: false,
+    cleanupPostcode: true,
   }) => {
     let realInput = Object.assign({}, input);
     realInput = normalizeComponentKeys(realInput);

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -590,5 +590,24 @@ Belgium
       expect(formatted[1]).toBe('10999 Berlin');
       expect(formatted[2]).toBe('Germany');
     });
+
+    it('should not clean postcode if option is set', () => {
+      const formatted = addressFormatter.format({
+        city: 'Berlin',
+        countryCode: 'de',
+        country: 'Germany',
+        houseNumber: undefined,
+        postcode: '10999,10999',
+        road: 'Glogauer Straße',
+      }, {
+        output: 'array',
+        cleanupPostcode: false,
+      },
+      );
+      expect(formatted.length).toBe(3);
+      expect(formatted[0]).toBe('Glogauer Straße');
+      expect(formatted[1]).toBe('10999,10999 Berlin');
+      expect(formatted[2]).toBe('Germany');
+    });
   });
 });


### PR DESCRIPTION
The available postcode cleanup/validation is a very rough implementation and should be optional because it does not cover all use cases.  