### PR TITLE
bug: add missing type for attention field

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,5 @@
+type AttentionInputType = 'attention';
+
 type PrimaryInputTypes =
   | 'archipelago'
   | 'city'
@@ -63,7 +65,7 @@ type AliasInputTypes =
   | 'township'
   | 'ward';
 
-type Input = Partial<Record<PrimaryInputTypes | AliasInputTypes, string>>;
+type Input = Partial<Record<AttentionInputType | PrimaryInputTypes | AliasInputTypes, string>>;
 
 interface CommonOptions {
   abbreviate?: boolean;


### PR DESCRIPTION
"attention" is not part of OpenCageData's [components.yaml](https://github.com/OpenCageData/address-formatting/blob/8d1cf9c84c343d1faee717198c0f46c593f38564/conf/components.yaml), so neither a PrimaryInputType nor an AliasInputType but still a valid key/part that is used in [address formatting](https://github.com/OpenCageData/address-formatting/blob/8d1cf9c84c343d1faee717198c0f46c593f38564/conf/countries/worldwide.yaml)

This pull request fixes TypeScript errors when using "attention" in the  format() function