### PR TITLE
add addressFormatter namespace to type declaration

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -67,20 +67,24 @@ type AliasInputTypes =
 
 type Input = Partial<Record<AttentionInputType | PrimaryInputTypes | AliasInputTypes, string>>;
 
-interface CommonOptions {
-  abbreviate?: boolean;
-  appendCountry?: boolean;
-  cleanupPostcode?: boolean;
-  countryCode?: string;
-  fallbackCountryCode?: string;
+export namespace addressFormatter {
+
+    interface CommonOptions {
+    abbreviate?: boolean;
+    appendCountry?: boolean;
+    cleanupPostcode?: boolean;
+    countryCode?: string;
+    fallbackCountryCode?: string;
+    }
+
+    export function format(
+    input: Input,
+    options?: CommonOptions & {output?: 'string'},
+    ): string;
+
+    export function format(
+    input: Input,
+    options: CommonOptions & {output: 'array'},
+    ): string[];
+
 }
-
-export function format(
-  input: Input,
-  options?: CommonOptions & {output?: 'string'},
-): string;
-
-export function format(
-  input: Input,
-  options: CommonOptions & {output: 'array'},
-): string[];


### PR DESCRIPTION
this is the types declaration fix for version 4.0.2 that uses named exports and not default exports, explanation in the ticket: https://github.com/fragaria/address-formatter/issues/672