### PR TITLE
Fix dead link to Photon

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ of that formatter.
 This library can format almost anything that comes out of
 Open Street Maps' [Nominatim API](https://wiki.openstreetmap.org/wiki/Nominatim)
 in the `address` field. Other compatible sources of data 
-such as [Photon](https://photon.komoot.de/) might be used as well.
+such as [Photon](https://photon.komoot.io/) might be used as well.
 
 It can automatically detect the country's
 formatting customs, but allows you to *pick a specific country


### PR DESCRIPTION
Photon linked to photon.komoot.de but is actually photon.komoot.io